### PR TITLE
Update GUI with improved labels and load logo image

### DIFF
--- a/NVDA-addon/addon/globalPlugins/MathCAT/MathCATPreferences.py
+++ b/NVDA-addon/addon/globalPlugins/MathCAT/MathCATPreferences.py
@@ -33,6 +33,11 @@ class UserInterface(MathCATgui.MathCATPreferencesDialog):
         #initialize parent class
         MathCATgui.MathCATPreferencesDialog.__init__(self,parent)
 
+        #load the logo into the dialog
+        full_path_to_logo = os.path.expanduser('~')+"\\AppData\\Roaming\\nvda\\addons\\mathCAT\\globalPlugins\\MathCAT\\logo.png"
+        if os.path.exists(full_path_to_logo):
+            self.m_bitmapLogo.SetBitmap(wx.Bitmap(full_path_to_logo))
+
         # load in the system values followed by the user prefs (if any)
         UserInterface.load_default_preferences()
         UserInterface.load_user_preferences()

--- a/NVDA-addon/addon/globalPlugins/MathCAT/MathCATgui.py
+++ b/NVDA-addon/addon/globalPlugins/MathCAT/MathCATgui.py
@@ -7,8 +7,8 @@
 ## PLEASE DO *NOT* EDIT THIS FILE!
 ###########################################################################
 
-#import wx
-import wx.xrc
+import wx
+#import wx.xrc
 
 import gettext
 _ = gettext.gettext

--- a/NVDA-addon/addon/globalPlugins/MathCAT/MathCATgui.py
+++ b/NVDA-addon/addon/globalPlugins/MathCAT/MathCATgui.py
@@ -7,7 +7,7 @@
 ## PLEASE DO *NOT* EDIT THIS FILE!
 ###########################################################################
 
-import wx
+#import wx
 import wx.xrc
 
 import gettext

--- a/NVDA-addon/addon/globalPlugins/MathCAT/MathCATgui.py
+++ b/NVDA-addon/addon/globalPlugins/MathCAT/MathCATgui.py
@@ -8,8 +8,7 @@
 ###########################################################################
 
 import wx
-# import wx.xrc
-import os
+import wx.xrc
 
 import gettext
 _ = gettext.gettext
@@ -44,7 +43,7 @@ class MathCATPreferencesDialog ( wx.Dialog ):
 
 		bSizerCategories.Add( ( 0, 0), 1, wx.EXPAND, 5 )
 
-		self.m_bitmapLogo = wx.StaticBitmap( self.m_panelCategories, wx.ID_ANY, wx.Bitmap( os.path.expanduser('~')+"\\AppData\\Roaming\\nvda\\addons\\MathCAT\\globalPlugins\\MathCAT\\logo.png", wx.BITMAP_TYPE_ANY ), wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.m_bitmapLogo = wx.StaticBitmap( self.m_panelCategories, wx.ID_ANY, wx.NullBitmap, wx.DefaultPosition, wx.Size( 126,85 ), 0 )
 		bSizerCategories.Add( self.m_bitmapLogo, 0, wx.ALL, 5 )
 
 
@@ -119,7 +118,7 @@ class MathCATPreferencesDialog ( wx.Dialog ):
 
 		bSizer7131 = wx.BoxSizer( wx.HORIZONTAL )
 
-		self.m_staticText21111 = wx.StaticText( self.m_panelSpeech, wx.ID_ANY, _(u"Relative speed:"), wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.m_staticText21111 = wx.StaticText( self.m_panelSpeech, wx.ID_ANY, _(u"Relative rate %:"), wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.m_staticText21111.Wrap( -1 )
 
 		bSizer7131.Add( self.m_staticText21111, 0, wx.ALL, 5 )

--- a/wxFormBuilder/MathCATgui.fbp
+++ b/wxFormBuilder/MathCATgui.fbp
@@ -19,7 +19,7 @@
         <property name="internationalize">1</property>
         <property name="name">MathCATPreferences</property>
         <property name="namespace"></property>
-        <property name="path">C:\Users\Rorme\source\repos\NSoiffer\MathCATForPython\NVDA-addon\addon\globalPlugins\MathCAT</property>
+        <property name="path">C:\Users\Rorme\OneDrive - DAISY Consortium\DAISY\Activities\Software tools\MathCAT\MathCATForPython\NVDA-addon\addon\globalPlugins\MathCAT</property>
         <property name="precompiled_header"></property>
         <property name="relative_path">1</property>
         <property name="skip_lua_events">1</property>
@@ -282,7 +282,7 @@
                                     <property name="aui_row"></property>
                                     <property name="best_size"></property>
                                     <property name="bg"></property>
-                                    <property name="bitmap">Load From File; logo.png</property>
+                                    <property name="bitmap"></property>
                                     <property name="caption"></property>
                                     <property name="caption_visible">1</property>
                                     <property name="center_pane">0</property>
@@ -316,7 +316,7 @@
                                     <property name="pos"></property>
                                     <property name="resize">Resizable</property>
                                     <property name="show">1</property>
-                                    <property name="size"></property>
+                                    <property name="size">126,85</property>
                                     <property name="subclass">; ; forward_declare</property>
                                     <property name="toolbar_pane">0</property>
                                     <property name="tooltip"></property>
@@ -1031,7 +1031,7 @@
                                                     <property name="gripper">0</property>
                                                     <property name="hidden">0</property>
                                                     <property name="id">wxID_ANY</property>
-                                                    <property name="label">Relative speed:</property>
+                                                    <property name="label">Relative rate %:</property>
                                                     <property name="markup">0</property>
                                                     <property name="max_size"></property>
                                                     <property name="maximize_button">0</property>
@@ -2195,7 +2195,7 @@
                                                     <property name="gripper">0</property>
                                                     <property name="hidden">0</property>
                                                     <property name="id">wxID_ANY</property>
-                                                    <property name="label">Highlight with dots 7 &amp; 8 the current nav node:</property>
+                                                    <property name="label">Highlight with dots 7 &amp;&amp; 8 the current nav node:</property>
                                                     <property name="markup">0</property>
                                                     <property name="max_size"></property>
                                                     <property name="maximize_button">0</property>

--- a/wxFormBuilder/MathCATgui.fbp
+++ b/wxFormBuilder/MathCATgui.fbp
@@ -19,7 +19,7 @@
         <property name="internationalize">1</property>
         <property name="name">MathCATPreferences</property>
         <property name="namespace"></property>
-        <property name="path">C:\Users\Rorme\OneDrive - DAISY Consortium\DAISY\Activities\Software tools\MathCAT\MathCATForPython\NVDA-addon\addon\globalPlugins\MathCAT</property>
+        <property name="path">..\NVDA-addon\addon\globalPlugins\MathCAT</property>
         <property name="precompiled_header"></property>
         <property name="relative_path">1</property>
         <property name="skip_lua_events">1</property>


### PR DESCRIPTION
Logo image is now loaded from within MathCATPreferences, so MathCATGUI is untouched after it is generated from wxFormBuilder.
Changed the label of the speech rate option, and changed the logo of the braille highlight option.
